### PR TITLE
Added cursor.description convenience and cursor.fetchmany

### DIFF
--- a/cx_Oracle_async/cursors.py
+++ b/cx_Oracle_async/cursors.py
@@ -20,6 +20,10 @@ class AsyncCursorWrapper:
         self._loop = loop
         self._thread_pool = thread_pool
 
+    @property
+    def description(self):
+        return self._cursor.description
+
     async def execute(self , sql , *args , **kwargs):
         if kwargs:
             return await self._loop.run_in_executor(
@@ -37,6 +41,10 @@ class AsyncCursorWrapper:
     async def fetchall(self):
         # block mainly happens when fetch triggered.
         return await self._loop.run_in_executor(self._thread_pool , self._cursor.fetchall)
+
+    async def fetchmany(self, *args, **kwargs):
+    # block mainly happens when fetch triggered.
+        return await self._loop.run_in_executor(self._thread_pool, self._cursor.fetchmany, *args, **kwargs)
 
     async def var(self, args):
         return await self._loop.run_in_executor(self._thread_pool , self._cursor.var, args)


### PR DESCRIPTION
## cursor.description
by the looks of it it should be available as `cursor._cursor.description` but anyways..  this is purely for convenience

see somone else was looking for this https://github.com/GoodManWEN/cx_Oracle_async/issues/19

## cursor.fetchmany
fetchone, fetchall, fetchmany are the main function calls on the db handlers. just to bring this cool project in line with those... (the fact that i needed it has noooothing to do with it :P) i added this in

use case (fetch 2 rows at a time as a dict):
```
await cur.execute(query)
desc = [d[0] for d in  cur.description]
while True:
    rows = await cur.fetchmany(2)
    if not rows: # no rows left so we done
        break
    for row in rows: 
        print(dict(zip(desc, row))) # this is a dict of each row now
```
